### PR TITLE
v1.3.11

### DIFF
--- a/400d30552fa0111049572f2ef699b65a/sys_app_400d30552fa0111049572f2ef699b65a.xml
+++ b/400d30552fa0111049572f2ef699b65a/sys_app_400d30552fa0111049572f2ef699b65a.xml
@@ -31,14 +31,14 @@
         <sys_id>400d30552fa0111049572f2ef699b65a</sys_id>
         <sys_mod_count>76</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-06-09 12:00:00</sys_updated_on>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
         <template/>
         <trackable>true</trackable>
         <uninstall_blocked>false</uninstall_blocked>
         <user_role display_value="x_ibmrt_gdpva.user" name="x_ibmrt_gdpva.user">2f4d81fd87940110387c64280cbb3566</user_role>
         <vendor/>
         <vendor_prefix/>
-        <version>1.3.10</version>
+        <version>1.3.11</version>
     </sys_app>
     <sys_attachment action="INSERT_OR_UPDATE">
         <average_image_color>#0</average_image_color>

--- a/400d30552fa0111049572f2ef699b65a/update/sn_sec_int_integration_24f0f5c687744d10387c64280cbb350c.xml
+++ b/400d30552fa0111049572f2ef699b65a/update/sn_sec_int_integration_24f0f5c687744d10387c64280cbb350c.xml
@@ -14,7 +14,7 @@
         <ire_source_name>VR-IBM-Guardium</ire_source_name>
         <is_auto_close_supported>true</is_auto_close_supported>
         <is_multi_source_supported>true</is_multi_source_supported>
-        <is_reapply_ci_lookup_supported>true</is_reapply_ci_lookup_supported>
+        <is_reapply_ci_lookup_supported>false</is_reapply_ci_lookup_supported>
         <lookup_by_network>false</lookup_by_network>
         <name>IBM Guardium Integration</name>
         <order>218</order>
@@ -24,14 +24,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2022-01-03 15:51:45</sys_created_on>
         <sys_id>24f0f5c687744d10387c64280cbb350c</sys_id>
-        <sys_mod_count>13</sys_mod_count>
+        <sys_mod_count>14</sys_mod_count>
         <sys_name>IBM Guardium Integration</sys_name>
         <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
         <sys_policy/>
         <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
         <sys_update_name>sn_sec_int_integration_24f0f5c687744d10387c64280cbb350c</sys_update_name>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-06-08 12:00:00</sys_updated_on>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
         <validation_script/>
     </sn_sec_int_integration>
 </record_update>

--- a/400d30552fa0111049572f2ef699b65a/update/sys_properties.xml
+++ b/400d30552fa0111049572f2ef699b65a/update/sys_properties.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record_update table="sys_properties">
+    <sys_properties action="INSERT_OR_UPDATE">
+        <choices/>
+        <description>IBM Guardium: maximum number of times to wait for a dependency to complete</description>
+        <ignore_cache>true</ignore_cache>
+        <is_private>false</is_private>
+        <name>x_ibmrt_gdpva.queue.max_attempts</name>
+        <read_roles/>
+        <suffix>x_ibmrt_gdpva</suffix>
+        <sys_class_name>sys_properties</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-06-12 12:00:00</sys_created_on>
+        <sys_id>bccb700b971369102cb5f1271153af55</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_ibmrt_gdpva.queue.max_attempts</sys_name>
+        <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
+        <sys_update_name>sys_properties_bccb700b971369102cb5f1271153af55</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
+        <type>integer</type>
+        <value>300</value>
+        <write_roles/>
+    </sys_properties>
+    <sys_properties action="INSERT_OR_UPDATE">
+        <choices/>
+        <description>IBM Guardium: run CI Lookup after Guardium Daily integration completes</description>
+        <ignore_cache>true</ignore_cache>
+        <is_private>false</is_private>
+        <name>x_ibmrt_gdpva.queue.run_ci_lookup</name>
+        <read_roles/>
+        <suffix>x_ibmrt_gdpva</suffix>
+        <sys_class_name>sys_properties</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-06-12 12:00:00</sys_created_on>
+        <sys_id>c1cb700b971369102cb5f1271153af94</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_ibmrt_gdpva.queue.run_ci_lookup</sys_name>
+        <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
+        <sys_update_name>sys_properties_c1cb700b971369102cb5f1271153af94</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
+        <type>boolean</type>
+        <value>true</value>
+        <write_roles/>
+    </sys_properties>
+    <sys_properties action="INSERT_OR_UPDATE">
+        <choices/>
+        <description>IBM Guardium: wait for assessment jobs to complete</description>
+        <ignore_cache>true</ignore_cache>
+        <is_private>false</is_private>
+        <name>x_ibmrt_gdpva.queue.wait_for_running_jobs</name>
+        <read_roles/>
+        <suffix>x_ibmrt_gdpva</suffix>
+        <sys_class_name>sys_properties</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-06-12 12:00:00</sys_created_on>
+        <sys_id>28cb300b971369102cb5f1271153af83</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_ibmrt_gdpva.queue.wait_for_running_jobs</sys_name>
+        <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
+        <sys_update_name>sys_properties_28cb300b971369102cb5f1271153af83</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
+        <type>boolean</type>
+        <value>true</value>
+        <write_roles/>
+    </sys_properties>
+    <sys_properties action="INSERT_OR_UPDATE">
+        <choices/>
+        <description>IBM Guardium: report used to import data source changes</description>
+        <ignore_cache>true</ignore_cache>
+        <is_private>false</is_private>
+        <name>x_ibmrt_gdpva.report.datasourcechanges</name>
+        <read_roles/>
+        <suffix>x_ibmrt_gdpva</suffix>
+        <sys_class_name>sys_properties</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-06-12 12:00:00</sys_created_on>
+        <sys_id>ddcbb00b971369102cb5f1271153af17</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_ibmrt_gdpva.report.datasourcechanges</sys_name>
+        <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
+        <sys_update_name>sys_properties_ddcbb00b971369102cb5f1271153af17</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
+        <type>string</type>
+        <value>DataSource Changes</value>
+        <write_roles/>
+    </sys_properties>
+    <sys_properties action="INSERT_OR_UPDATE">
+        <choices/>
+        <description>IBM Guardium: report used to import data sources</description>
+        <ignore_cache>true</ignore_cache>
+        <is_private>false</is_private>
+        <name>x_ibmrt_gdpva.report.datasources</name>
+        <read_roles/>
+        <suffix>x_ibmrt_gdpva</suffix>
+        <sys_class_name>sys_properties</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-06-12 12:00:00</sys_created_on>
+        <sys_id>15cb700b971369102cb5f1271153afc4</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_ibmrt_gdpva.report.datasources</sys_name>
+        <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
+        <sys_update_name>sys_properties_15cb700b971369102cb5f1271153afc4</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
+        <type>string</type>
+        <value>Data-Sources</value>
+        <write_roles/>
+    </sys_properties>
+    <sys_properties action="INSERT_OR_UPDATE">
+        <choices/>
+        <description>IBM Guardium: report used to import test result details</description>
+        <ignore_cache>true</ignore_cache>
+        <is_private>false</is_private>
+        <name>x_ibmrt_gdpva.report.test_result_details</name>
+        <read_roles/>
+        <suffix>x_ibmrt_gdpva</suffix>
+        <sys_class_name>sys_properties</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-06-12 12:00:00</sys_created_on>
+        <sys_id>65cbb00b971369102cb5f1271153af31</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_ibmrt_gdpva.report.test_result_details</sys_name>
+        <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
+        <sys_update_name>sys_properties_65cbb00b971369102cb5f1271153af31</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
+        <type>string</type>
+        <value>Security Assessment Export</value>
+        <write_roles/>
+    </sys_properties>
+    <sys_properties action="INSERT_OR_UPDATE">
+        <choices/>
+        <description>IBM Guardium: report used to import test result summary</description>
+        <ignore_cache>true</ignore_cache>
+        <is_private>false</is_private>
+        <name>x_ibmrt_gdpva.report.test_result_summary</name>
+        <read_roles/>
+        <suffix>x_ibmrt_gdpva</suffix>
+        <sys_class_name>sys_properties</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-06-12 12:00:00</sys_created_on>
+        <sys_id>69cbb00b971369102cb5f1271153af57</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_ibmrt_gdpva.report.test_result_summary</sys_name>
+        <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
+        <sys_update_name>sys_properties_69cbb00b971369102cb5f1271153af57</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
+        <type>string</type>
+        <value>Assessment summary</value>
+        <write_roles/>
+    </sys_properties>
+    <sys_properties action="INSERT_OR_UPDATE">
+        <choices/>
+        <description>IBM Guardium: report used to import third party vulnerability tests</description>
+        <ignore_cache>true</ignore_cache>
+        <is_private>false</is_private>
+        <name>x_ibmrt_gdpva.report.vulnerability_tests</name>
+        <read_roles/>
+        <suffix>x_ibmrt_gdpva</suffix>
+        <sys_class_name>sys_properties</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-06-12 12:00:00</sys_created_on>
+        <sys_id>b1cbb00b971369102cb5f1271153af71</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_ibmrt_gdpva.report.vulnerability_tests</sys_name>
+        <sys_package display_value="IBM Guardium Data Protection" source="x_ibmrt_gdpva">400d30552fa0111049572f2ef699b65a</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="IBM Guardium Data Protection">400d30552fa0111049572f2ef699b65a</sys_scope>
+        <sys_update_name>sys_properties_b1cbb00b971369102cb5f1271153af71</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-06-12 12:00:00</sys_updated_on>
+        <type>string</type>
+        <value>Available VA tests - detailed</value>
+        <write_roles/>
+    </sys_properties>
+</record_update>

--- a/400d30552fa0111049572f2ef699b65a/update/sys_script_include_f902427b1b711d10e89f21be6e4bcb01.xml
+++ b/400d30552fa0111049572f2ef699b65a/update/sys_script_include_f902427b1b711d10e89f21be6e4bcb01.xml
@@ -86,19 +86,23 @@ GuardiumIntegrationDaily.prototype =
             return null; // don't return any data
         },
 
-        logVersion: function() {
+        logVersion: function(sTable) {
             try {
-                var gr = new GlideRecord('sys_app');
+                var gr = new GlideRecord(sTable || 'sys_store_app');
                 if (gr.get('400d30552fa0111049572f2ef699b65a')) {
                     GuardiumLog.info([
                         'App:', gr.getValue('name'),
                         ', Version:', gr.getValue('version'),
                         ', Updated:', gr.getValue('sys_updated_on')
                     ].join(' '), this.type);
+                    return true;
                 }
             } catch (e) {
-                GuardiumLog.error('Unable to get application version', this.type, e);
+                if (!this.logVersion('sys_app')) {
+                    GuardiumLog.error('Unable to get application version', this.type, e);
+                }
             }
+            return false;
         },
 
         hasPreviousRun: function() {


### PR DESCRIPTION
Minor update from certification review:

- sys_properties - with correct data type and ignore_cache=true
- sys_store_app - log version from sys_store_app first, and if failed, use sys_app
- is_reapply_ci_lookup_supported=false
```
<sn_sec_int_integration>
      <is_reapply_ci_lookup_supported>false</is_reapply_ci_lookup_supported>
</sn_sec_int_integration>
```